### PR TITLE
downgrading checkout action to v3

### DIFF
--- a/.github/workflows/checkmarx-scan-on-pull.yml
+++ b/.github/workflows/checkmarx-scan-on-pull.yml
@@ -50,7 +50,7 @@ jobs:
     # Steps require - checkout code, run CxFlow Action, Upload SARIF report (optional)
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
     # Runs the Checkmarx Scan leveraging the latest version of CxFlow - REFER to Action README for list of inputs
     - name: Checkmarx CxFlow Action
       uses: checkmarx-ts/checkmarx-cxflow-github-action@49d8269b14ca87910ba003d47a31fa0c7a11f2fe


### PR DESCRIPTION
downgrading checkout action to v3 as our ec2 instance does not support a high enough version of glibc for v4